### PR TITLE
Change max encrypted document and max chunk size

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,8 +489,7 @@ sysadmin controls the keys, not the user.
 The fundamental unit of storage in data vaults is the encrypted
 structured document which, when decrypted, provides a data structure that
 can be expressed in popular syntaxes such as JSON and CBOR. Documents can
-store structured data and metadata about the structured data. Structured
-document sizes are limited to 16MB.
+store structured data and metadata about the structured data.
         </p>
       </section>
 
@@ -500,7 +499,7 @@ document sizes are limited to 16MB.
         </h2>
 
         <p>
-For files larger than 16MB or for raw binary data formats such as audio,
+For files larger than 10MiB or for raw binary data formats such as audio,
 video, and office productivity files, a streaming API is provided that
 enables data to be streamed to/from a data vault. Streams are described using
 structured documents, but the storage of the data is separated from the
@@ -761,7 +760,7 @@ sizes. For example, some databases set the maximum size for a single record to
 are easily managed by a server. It is the responsibility of the client to set
 the chunk size of each resource and chunk large data into manageable chunks for
 the server. It is the responsibility of the server to deny requests to store
-chunks larger that it can handle.
+chunks larger than 1MiB, which is the maximum size for a single chunk.
           </p>
           <p>
 Each chunk is encrypted individually using authenticated encryption. Doing so
@@ -1177,7 +1176,8 @@ Encrypted Data Vault
           <p>
   An encrypted document is used to store a structured document in a way that
   ensures that no entity can read the information without the consent of the
-  data controller.
+  data controller. An encrypted document's size (as measured by the size of
+  the HTTP body containing the encrypted document) MUST NOT exceed 10MiB.
           </p>
 
           <p class="issue">
@@ -1922,8 +1922,9 @@ Encrypted Data Vault
           <p>
   A stream is stored in a data vault by writing a document containing metadata
   about the stream, encrypting the stream, writing it to a data vault, and then
-  updating the document containing metadata about the stream. The following
-  HTTP status codes are defined for this service:
+  updating the document containing metadata about the stream. A chunk's size (as
+  measured by the size of the HTTP body containing the chunk) MUST NOT exceed 1MiB.
+  The following HTTP status codes are defined for this service:
           </p>
 
           <table class="simple">


### PR DESCRIPTION
closes #22

- Max encrypted document size is now 10MiB (used to be 16MB).
- Updated some text to indicate that the limit is on Encrypted Documents, not Structured Documents.